### PR TITLE
Update maven assembly plugin version to 2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /target
 .DS_Store
 *.iml
+/.project
+/.classpath
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.2.2</version>
+                <version>2.3</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <outputDirectory>${project.build.directory}/releases/</outputDirectory>


### PR DESCRIPTION
As discussed, here is the pull request.
- Update maven assembly plugin to latest version : 2.3
- Ignore eclipse files
